### PR TITLE
Fix memory transition call in vit2

### DIFF
--- a/VisionTitans/vit2.py
+++ b/VisionTitans/vit2.py
@@ -48,8 +48,14 @@ class ResidualNorm(nn.Module):
         self.norm = nn.LayerNorm(dim)
         self.fn = fn
 
-    def forward(self, x):
-        return x + self.fn(self.norm(x))
+    def forward(self, x, *args, **kwargs):
+        """Apply function with residual connection.
+
+        Extra positional and keyword arguments are forwarded to ``self.fn`` so
+        that wrapped functions can accept additional inputs (e.g. memory
+        tensors).
+        """
+        return x + self.fn(self.norm(x), *args, **kwargs)
 
 # --- Transformer Encoder ---
 class MultiScaleEncoder(nn.Module):


### PR DESCRIPTION
## Summary
- allow ResidualNorm to forward extra arguments to the wrapped function

## Testing
- `python -m py_compile VisionTitans/vit.py VisionTitans/vit2.py persistent_m/persm.py`

------
https://chatgpt.com/codex/tasks/task_e_6840fb2f706c832ebb33bb86fd1d004a